### PR TITLE
feat: respect prettier config of project

### DIFF
--- a/lib/rules/format-query-block.js
+++ b/lib/rules/format-query-block.js
@@ -21,6 +21,7 @@ module.exports = {
   },
   create(context) {
     const sourceCode = context.getSourceCode();
+    const filePath = context.getFilename();
     return {
       Program(node) {
         if (!node.templateBody) {
@@ -37,11 +38,18 @@ module.exports = {
               node.endTag ? node.endTag.range[0] : node.range[1]
             ];
             const code = sourceCode.text.slice(...codeRange).trim();
+            const prettierConfig = prettier.resolveConfig.sync(filePath, {
+              editorconfig: true
+            });
 
             const formattedCode = prettier
-              .format(code, {
-                parser: prettierParser
-              })
+              .format(code, Object.assign(
+                {},
+                prettierConfig,
+                {
+                  parser: prettierParser
+                }
+              ))
               .trim();
 
             if (formattedCode !== code) {

--- a/tests/fixture/fixture.vue
+++ b/tests/fixture/fixture.vue
@@ -11,7 +11,7 @@ query Blog {
   allWordPressPost(limit: 5) {
     edges {
       node {
-              id
+        id
         title
       }
     }


### PR DESCRIPTION
# Check

- [x] Pass the rule's test. : `yarn test`
- [ ] Fill the rule's docs.
- [ ] Create files by Hygen. : `yarn gen:rule`

# What

Makes the query block format rule respect the prettier config of the project.

# Related issue
