### PR TITLE
Added parser option

### DIFF
--- a/lib/configs/recommended.js
+++ b/lib/configs/recommended.js
@@ -11,5 +11,8 @@ module.exports = {
     "gridsome/format-query-block": "warn",
     "gridsome/require-g-image-src": "error",
     "gridsome/require-g-link-to": "warn"
+  },
+  "parserOptions": {
+    "sourceType": "module"
   }
 };


### PR DESCRIPTION
Gets rid of this error from eslint:
```
Parsing error: 'import' and 'export' may appear only with 'sourceType: module' eslint
```

<!-- Fill all list -->

# Check

- [ ] Pass the rule's test. : `yarn test`
- [ ] Fill the rule's docs.
- [ ] Create files by Hygen. : `yarn gen:rule`

<!-- Explanation of this PRs -->

# What

# Related issue
