### PR TITLE
refactor: refactor g-link consider href

### DIFF
--- a/docs/rules/require-g-link-to.md
+++ b/docs/rules/require-g-link-to.md
@@ -2,7 +2,7 @@
 
 ## :book: Rule Details
 
-- This rule reports the `<g-link>` elements which do not have `v-bind:to` or `to`.
+- This rule reports the `<g-link>` elements which do not have `v-bind:to`, `to` or `v-bind:href`, `href`.
 
 :-1: Examples of **incorrect** code for this rule:
 
@@ -22,6 +22,9 @@
     <g-link to="/" class="foo">link is here</g-link>
     <g-link :to="article.path" class="foo">link is here</g-link>
     <g-link :to="{ name: 'about' }" class="foo">link is here</g-link>
+    <g-link href="http://www.example.com" class="foo">link is here</g-link>
+    <g-link href="https://www.example.com" class="foo">link is here</g-link>
+    <g-link :href="absolute.link" class="foo">link is here</g-link>
   </div>
 </template>
 ```

--- a/lib/rules/require-g-link-to.js
+++ b/lib/rules/require-g-link-to.js
@@ -24,16 +24,27 @@ module.exports = {
     }
   },
   create(context) {
+    const statementTo = node => {
+      return (
+        !utils.hasAttribute(node, "to") &&
+        !utils.hasDirective(node, "bind", "to")
+      );
+    };
+    const statementHref = node => {
+      return (
+        !utils.hasAttribute(node, "href") &&
+        !utils.hasDirective(node, "bind", "href")
+      );
+    };
+
     return utils.defineTemplateBodyVisitor(context, {
       "VElement[name='g-link']"(node) {
-        if (
-          !utils.hasAttribute(node, "to") &&
-          !utils.hasDirective(node, "bind", "to")
-        ) {
+        if (statementTo(node) && statementHref(node)) {
           context.report({
             node: node,
             loc: node.loc,
-            message: "Expected '<g-link>' elements to have 'v-bind:to' or 'to'."
+            message:
+              "Expected '<g-link>' elements to have 'v-bind:to', 'to' or 'v-bind:href', 'href'."
           });
         }
       }

--- a/tests/lib/rules/require-g-link-to.js
+++ b/tests/lib/rules/require-g-link-to.js
@@ -98,7 +98,9 @@ tester.run("require-g-link-to", rule, {
         link is here
         </g-link>
       </template>`,
-      errors: ["Expected '<g-link>' elements to have 'v-bind:to' or 'to'."]
+      errors: [
+        "Expected '<g-link>' elements to have 'v-bind:to', 'to' or 'v-bind:href', 'href'."
+      ]
     }
   ]
 });

--- a/tests/lib/rules/require-g-link-to.js
+++ b/tests/lib/rules/require-g-link-to.js
@@ -53,6 +53,39 @@ tester.run("require-g-link-to", rule, {
         link is here
         </g-link>
       </template>`
+    },
+    {
+      code: `
+      <template>
+        <g-link
+          href="http://www.example.com"
+          class="foo"
+        >
+        link is here
+        </g-link>
+      </template>`
+    },
+    {
+      code: `
+      <template>
+        <g-link
+          href="https://www.example.com"
+          class="foo"
+        >
+        link is here
+        </g-link>
+      </template>`
+    },
+    {
+      code: `
+      <template>
+        <g-link
+          :href="absolute.url"
+          class="foo"
+        >
+        link is here
+        </g-link>
+      </template>`
     }
   ],
   invalid: [


### PR DESCRIPTION
closes #34

<!-- Fill all list -->

# Check

- [x] Pass the rule's test. : `yarn test`
- [x] Fill the rule's docs.
- [ ] Create files by Hygen. : `yarn gen:rule`

<!-- Explanation of this PRs -->

# What
require-g-link-to consider `href` and `:href`

# Related issue
