### PR TITLE
WIP refactor(format-query-block): add baseIndent option

### DIFF
--- a/docs/rules/format-query-block.md
+++ b/docs/rules/format-query-block.md
@@ -4,6 +4,7 @@
 
 - This rule checks the consistency of a code in `<page-query>` and `<static-query>` tags.
 - This rule's formatter is [Prettier](https://prettier.io). [Parser is `graphql`](https://prettier.io/docs/en/options.html#parser)
+- If you use `.prettierrc`, this rule is check that file. Consider option `tabWidth` and `useTabs`.
 
 ## :book: Rule Details
 

--- a/lib/rules/format-query-block.js
+++ b/lib/rules/format-query-block.js
@@ -8,71 +8,19 @@
 // ------------------------------------------------------------------------------
 // Requirements
 // ------------------------------------------------------------------------------
-
 const prettier = require("prettier");
+const {
+  getPrettierDefaultOptions,
+  getPrettierRcOptions,
+  getMergedPrettierOptions
+} = require("../utils/getPrettierOptions");
+const getIndentOptions = require("../utils/getIndentOptions");
 
 // ------------------------------------------------------------------------------
 // Settings
 // ------------------------------------------------------------------------------
 const prettierParser = "graphql";
 const LINES = /[^\r\n\u2028\u2029]+(?:$|\r\n|[\r\n\u2028\u2029])/g;
-
-/**
- * Prettier's default options that Prettier settings
- * @return {Object} { optionsName: optionsDefaultValue }
- */
-const prettierDefaultOptions = prettier
-  .getSupportInfo(prettier.version)
-  .options.reduce((result, current) => {
-    result[current.name] = current.default;
-    return result;
-  }, {});
-
-/**
- * Get Prettier's options that user settings
- * @param {string} filePath File path that formatted with Prettier
- * @return {Object} { optionsName: optionsDefaultValue }
- */
-const getPrettierOptions = filePath => {
-  return prettier.resolveConfig.sync(filePath, {
-    editorconfig: true
-  });
-};
-
-/**
- * Get merged options that Prettier's default options and user settings options
- * @param {object} prettierDefaultOptions
- * @param {object} prettierOptions
- * @return {object} Merged options
- */
-const getMergedPrettierOptions = (prettierDefaultOptions, prettierOptions) => {
-  return { ...prettierDefaultOptions, ...prettierOptions };
-};
-
-/**
- * Get indent options
- * @param {object} mergedPrettierOptions
- * @return {object}
- */
-const getIndentOptions = mergedPrettierOptions => {
-  const defaultOptions = {
-    baseIndent: 0,
-    indentChar: " "
-  };
-
-  const { tabWidth, useTabs } = mergedPrettierOptions;
-
-  const result = {
-    baseIndent: tabWidth
-  };
-
-  if (useTabs) {
-    result.baseIndent = 1;
-    result.indentChar = "\t";
-  }
-
-  return { ...defaultOptions, ...result };
-};
 
 module.exports = {
   meta: {
@@ -91,8 +39,8 @@ module.exports = {
     const filePath = context.getFilename();
 
     const mergedPrettierOptions = getMergedPrettierOptions(
-      prettierDefaultOptions,
-      getPrettierOptions(filePath)
+      getPrettierDefaultOptions,
+      getPrettierRcOptions(filePath)
     );
 
     const { baseIndent, indentChar } = getIndentOptions(mergedPrettierOptions);
@@ -129,10 +77,17 @@ module.exports = {
               )
               .trim();
 
-            let lines = prettierCode.match(LINES);
+            let lines;
+            lines = prettierCode.match(LINES);
             lines = ["\n", ...lines, "\n"];
 
-            const formattedCode = lines.map(line => indent + line).join("");
+            const formattedCode = lines
+              .map(line => {
+                if (line === "\n") return line;
+                return indent + line;
+              })
+              .join("");
+            // const formattedCode = lines.map(line => indent + line).join("");
 
             if (formattedCode !== code) {
               context.report({

--- a/lib/rules/format-query-block.js
+++ b/lib/rules/format-query-block.js
@@ -9,7 +9,7 @@ const prettier = require("prettier");
 const prettierParser = "graphql";
 
 /**
- * Prettier's options that Prettier settings
+ * Prettier's default options that Prettier settings
  * @return {Object} { optionsName: optionsDefaultValue }
  */
 const prettierDefaultOptions = prettier
@@ -21,7 +21,7 @@ const prettierDefaultOptions = prettier
 
 /**
  * Get Prettier's options that user settings
- * @param {*} filePath File path that formatted with Prettier
+ * @param {string} filePath File path that formatted with Prettier
  * @return {Object} { optionsName: optionsDefaultValue }
  */
 const getPrettierOptions = filePath => {
@@ -45,20 +45,21 @@ const getMergedPrettierOptions = (prettierDefaultOptions, prettierOptions) => {
  * @param {object} mergedPrettierOptions
  * @return {object}
  */
-const getIndentOptions = (mergedPrettierOptions, options) => {
+const getIndentOptions = mergedPrettierOptions => {
   const defaultOptions = {
     baseIndent: 0,
     indentChar: " "
   };
 
-  const { tabWidth } = mergedPrettierOptions;
+  const { tabWidth, useTabs } = mergedPrettierOptions;
 
   const result = {
     baseIndent: tabWidth
   };
 
-  if (options.baseIndent) {
-    result.baseIndent = options.baseIndent;
+  if (useTabs) {
+    result.baseIndent = 0;
+    result.indentChar = "\t";
   }
 
   return { ...defaultOptions, ...result };
@@ -74,29 +75,18 @@ module.exports = {
       url:
         "https://github.com/gridsome/eslint-plugin-gridsome/blob/master/docs/rules/format-query-block.md"
     },
-    schema: [
-      {
-        type: "object",
-        property: {
-          baseIndent: { type: "integer", minimum: 0 }
-        }
-      }
-    ]
+    schema: []
   },
   create(context) {
     const sourceCode = context.getSourceCode();
     const filePath = context.getFilename();
-    const options = context.options[0];
 
     const mergedPrettierOptions = getMergedPrettierOptions(
       prettierDefaultOptions,
       getPrettierOptions(filePath)
     );
 
-    const { baseIndent, indentChar } = getIndentOptions(
-      mergedPrettierOptions,
-      options
-    );
+    const { baseIndent, indentChar } = getIndentOptions(mergedPrettierOptions);
 
     return {
       Program(node) {

--- a/lib/rules/format-query-block.js
+++ b/lib/rules/format-query-block.js
@@ -17,11 +17,24 @@ module.exports = {
         "Format fix for `<page-query>` and `<static-query>` in .vue. Using Prettier API",
       url:
         "https://github.com/gridsome/eslint-plugin-gridsome/blob/master/docs/rules/format-query-block.md"
-    }
+    },
+    schema: [
+      {
+        type: "object",
+        property: {
+          baseIndent: { type: "integer", minimum: 0 }
+        }
+      }
+    ]
   },
   create(context) {
     const sourceCode = context.getSourceCode();
     const filePath = context.getFilename();
+    const defaultOption = {
+      baseIndent: 0
+    };
+    const { baseIndent } = context.options[0] || defaultOption;
+
     return {
       Program(node) {
         if (!node.templateBody) {
@@ -38,19 +51,22 @@ module.exports = {
               node.endTag ? node.endTag.range[0] : node.range[1]
             ];
             const code = sourceCode.text.slice(...codeRange).trim();
+
             const prettierConfig = prettier.resolveConfig.sync(filePath, {
               editorconfig: true
             });
 
             const formattedCode = prettier
-              .format(code, Object.assign(
-                {},
-                prettierConfig,
-                {
+              .format(
+                code,
+                Object.assign({}, prettierConfig, {
                   parser: prettierParser
-                }
-              ))
-              .trim();
+                })
+              )
+              .trim()
+              .replace(/(.*)/gm, match => {
+                return `${" ".repeat(baseIndent)}${match}`;
+              });
 
             if (formattedCode !== code) {
               context.report({

--- a/lib/rules/format-query-block.js
+++ b/lib/rules/format-query-block.js
@@ -5,8 +5,17 @@
  */
 "use strict";
 
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
 const prettier = require("prettier");
+
+// ------------------------------------------------------------------------------
+// Settings
+// ------------------------------------------------------------------------------
 const prettierParser = "graphql";
+const LINES = /[^\r\n\u2028\u2029]+(?:$|\r\n|[\r\n\u2028\u2029])/g;
 
 /**
  * Prettier's default options that Prettier settings
@@ -58,7 +67,7 @@ const getIndentOptions = mergedPrettierOptions => {
   };
 
   if (useTabs) {
-    result.baseIndent = 0;
+    result.baseIndent = 1;
     result.indentChar = "\t";
   }
 
@@ -87,6 +96,7 @@ module.exports = {
     );
 
     const { baseIndent, indentChar } = getIndentOptions(mergedPrettierOptions);
+    const indent = indentChar.repeat(baseIndent);
 
     return {
       Program(node) {
@@ -103,13 +113,14 @@ module.exports = {
               node.startTag.range[1],
               node.endTag ? node.endTag.range[0] : node.range[1]
             ];
-            const code = sourceCode.text.slice(...codeRange).trim();
+
+            const code = sourceCode.text.slice(...codeRange);
 
             const prettierConfig = prettier.resolveConfig.sync(filePath, {
               editorconfig: true
             });
 
-            const formattedCode = prettier
+            const prettierCode = prettier
               .format(
                 code,
                 Object.assign({}, prettierConfig, {
@@ -118,9 +129,10 @@ module.exports = {
               )
               .trim();
 
-            formattedCode.replace(/(.*)/gm, match => {
-              return `${indentChar.repeat(baseIndent)}${match}`;
-            });
+            let lines = prettierCode.match(LINES);
+            lines = ["\n", ...lines, "\n"];
+
+            const formattedCode = lines.map(line => indent + line).join("");
 
             if (formattedCode !== code) {
               context.report({
@@ -128,10 +140,7 @@ module.exports = {
                 message: `${node.name} code format is incorrect`,
 
                 fix(fixer) {
-                  return fixer.replaceTextRange(
-                    codeRange,
-                    `\n${formattedCode}\n`
-                  );
+                  return fixer.replaceTextRange(codeRange, formattedCode);
                 }
               });
             }

--- a/lib/rules/format-query-block.js
+++ b/lib/rules/format-query-block.js
@@ -8,6 +8,62 @@
 const prettier = require("prettier");
 const prettierParser = "graphql";
 
+/**
+ * Prettier's options that Prettier settings
+ * @return {Object} { optionsName: optionsDefaultValue }
+ */
+const prettierDefaultOptions = prettier
+  .getSupportInfo(prettier.version)
+  .options.reduce((result, current) => {
+    result[current.name] = current.default;
+    return result;
+  }, {});
+
+/**
+ * Get Prettier's options that user settings
+ * @param {*} filePath File path that formatted with Prettier
+ * @return {Object} { optionsName: optionsDefaultValue }
+ */
+const getPrettierOptions = filePath => {
+  return prettier.resolveConfig.sync(filePath, {
+    editorconfig: true
+  });
+};
+
+/**
+ * Get merged options that Prettier's default options and user settings options
+ * @param {object} prettierDefaultOptions
+ * @param {object} prettierOptions
+ * @return {object} Merged options
+ */
+const getMergedPrettierOptions = (prettierDefaultOptions, prettierOptions) => {
+  return { ...prettierDefaultOptions, ...prettierOptions };
+};
+
+/**
+ * Get indent options
+ * @param {object} mergedPrettierOptions
+ * @return {object}
+ */
+const getIndentOptions = (mergedPrettierOptions, options) => {
+  const defaultOptions = {
+    baseIndent: 0,
+    indentChar: " "
+  };
+
+  const { tabWidth } = mergedPrettierOptions;
+
+  const result = {
+    baseIndent: tabWidth
+  };
+
+  if (options.baseIndent) {
+    result.baseIndent = options.baseIndent;
+  }
+
+  return { ...defaultOptions, ...result };
+};
+
 module.exports = {
   meta: {
     type: "layout",
@@ -30,10 +86,17 @@ module.exports = {
   create(context) {
     const sourceCode = context.getSourceCode();
     const filePath = context.getFilename();
-    const defaultOption = {
-      baseIndent: 0
-    };
-    const { baseIndent } = context.options[0] || defaultOption;
+    const options = context.options[0];
+
+    const mergedPrettierOptions = getMergedPrettierOptions(
+      prettierDefaultOptions,
+      getPrettierOptions(filePath)
+    );
+
+    const { baseIndent, indentChar } = getIndentOptions(
+      mergedPrettierOptions,
+      options
+    );
 
     return {
       Program(node) {
@@ -63,10 +126,11 @@ module.exports = {
                   parser: prettierParser
                 })
               )
-              .trim()
-              .replace(/(.*)/gm, match => {
-                return `${" ".repeat(baseIndent)}${match}`;
-              });
+              .trim();
+
+            formattedCode.replace(/(.*)/gm, match => {
+              return `${indentChar.repeat(baseIndent)}${match}`;
+            });
 
             if (formattedCode !== code) {
               context.report({

--- a/lib/utils/getIndentOptions.js
+++ b/lib/utils/getIndentOptions.js
@@ -1,0 +1,26 @@
+/**
+ * Get indent options
+ * @param {object} mergedPrettierOptions
+ * @return {object}
+ */
+const getIndentOptions = mergedPrettierOptions => {
+  const defaultOptions = {
+    baseIndent: 0,
+    indentChar: " "
+  };
+
+  const { tabWidth, useTabs } = mergedPrettierOptions;
+
+  const result = {
+    baseIndent: tabWidth
+  };
+
+  if (useTabs) {
+    result.baseIndent = 1;
+    result.indentChar = "\t";
+  }
+
+  return { ...defaultOptions, ...result };
+};
+
+module.exports = getIndentOptions;

--- a/lib/utils/getPrettierOptions.js
+++ b/lib/utils/getPrettierOptions.js
@@ -1,0 +1,42 @@
+const prettier = require("prettier");
+
+/**
+ * Get Prettier's default options that Prettier settings
+ * @return {Object} { optionsName: optionsDefaultValue }
+ */
+const getPrettierDefaultOptions = prettier
+  .getSupportInfo(prettier.version)
+  .options.reduce((result, current) => {
+    result[current.name] = current.default;
+    return result;
+  }, {});
+
+/**
+ * Get Prettier's options that user settings
+ * @param {string} filePath File path that formatted with Prettier
+ * @return {Object} { optionsName: optionsDefaultValue }
+ */
+const getPrettierRcOptions = filePath => {
+  return prettier.resolveConfig.sync(filePath, {
+    editorconfig: true
+  });
+};
+
+/**
+ * Get merged options that Prettier's default options and user settings options
+ * @param {object} prettierDefaultOptions
+ * @param {object} prettierRcOptions
+ * @return {object} Merged options
+ */
+const getMergedPrettierOptions = (
+  prettierDefaultOptions,
+  prettierRcOptions
+) => {
+  return { ...prettierDefaultOptions, ...prettierRcOptions };
+};
+
+module.exports = {
+  getPrettierDefaultOptions,
+  getPrettierRcOptions,
+  getMergedPrettierOptions
+};

--- a/tests/lib/rules/format-query-block.js
+++ b/tests/lib/rules/format-query-block.js
@@ -69,16 +69,16 @@ query Blog {
       output: `
 <template></template>
 <page-query>
-query Blog {
-  allWordPressPost(limit: 5) {
-    edges {
-      node {
-        id
-        title
+  query Blog {
+    allWordPressPost(limit: 5) {
+      edges {
+        node {
+          id
+          title
+        }
       }
     }
   }
-}
 </page-query>
     `,
       errors: ["page-query code format is incorrect"]
@@ -97,11 +97,11 @@ query Blog {
       output: `
 <template></template>
 <static-query>
-query Example {
-  example: examplePage(path: "/docs/example") {
-    content
+  query Example {
+    example: examplePage(path: "/docs/example") {
+      content
+    }
   }
-}
 </static-query>
     `,
       errors: ["static-query code format is incorrect"]


### PR DESCRIPTION
re #39

<!-- Fill all list -->

# Check

- [x] Pass the rule's test. : `npm run test`
- [x] Fill the rule's docs.
- [ ] Create files by Hygen. : `npm run gen:rule`

<!-- Explanation of this PRs -->

# What
~~add `baseIndent` option for `format-query-block`~~
~~similar https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/script-indent.md~~
format-query-block see `tabWidth` and `useTabs` in`.prettierrc`.

# Related issue
