### PR TITLE
feat: Support break line

### DIFF
--- a/lib/rules/format-query-block.js
+++ b/lib/rules/format-query-block.js
@@ -20,7 +20,7 @@ const getIndentOptions = require("../utils/getIndentOptions");
 // Settings
 // ------------------------------------------------------------------------------
 const prettierParser = "graphql";
-const LINES = /[^\r\n\u2028\u2029]+(?:$|\r\n|[\r\n\u2028\u2029])/g;
+const LINES = /[^\r\n\u2028\u2029]+(?:$|\r\n|[\r\n\u2028\u2029])|\s/g;
 
 module.exports = {
   meta: {
@@ -36,6 +36,7 @@ module.exports = {
   },
   create(context) {
     const sourceCode = context.getSourceCode();
+
     const filePath = context.getFilename();
 
     const mergedPrettierOptions = getMergedPrettierOptions(
@@ -52,6 +53,7 @@ module.exports = {
           return;
         }
         const topLevelNodes = node.templateBody.parent.children;
+
         for (const node of topLevelNodes) {
           if (
             (node.type === "VElement" && node.name === "page-query") ||

--- a/lib/rules/format-query-block.js
+++ b/lib/rules/format-query-block.js
@@ -87,7 +87,6 @@ module.exports = {
                 return indent + line;
               })
               .join("");
-            // const formattedCode = lines.map(line => indent + line).join("");
 
             if (formattedCode !== code) {
               context.report({

--- a/tests/lib/rules/format-query-block.js
+++ b/tests/lib/rules/format-query-block.js
@@ -24,27 +24,58 @@ tester.run("format-query-block", rule, {
     {
       code: `
 <page-query>
-query Blog {
-  allWordPressPost(limit: 5) {
-    edges {
-      node {
-        id
-        title
+  query Blog {
+    allWordPressPost(limit: 5) {
+      edges {
+        node {
+          id
+          title
+        }
       }
     }
   }
-}
+</page-query>
+    `
+    },
+    {
+      code: `
+<page-query>
+  fragment RankingParts on TourRanking {
+    id
+    rankings: data {
+      rank
+      nickname
+      score
+      badge: pin_badge_image_url
+      ranking_started_at
+      ranking_finished_at
+    }
+  }
+
+  query($id: ID, $prevId: ID, $nextId: ID) {
+    ranking: tourRanking(id: $id) {
+      ...RankingParts
+    }
+
+    next: tourRanking(id: $prevId) {
+      ...RankingParts
+    }
+
+    prev: tourRanking(id: $nextId) {
+      ...RankingParts
+    }
+  }
 </page-query>
     `
     },
     {
       code: `
 <static-query>
-query Example {
-  example: examplePage(path: "/docs/example") {
+  query Example {
+    example: examplePage(path: "/docs/example") {
     content
+    }
   }
-}
 </static-query>
     `
     }
@@ -74,6 +105,42 @@ query Blog {
       edges {
         node {
           id
+          title
+        }
+      }
+    }
+  }
+</page-query>
+    `,
+      errors: ["page-query code format is incorrect"]
+    },
+    {
+      code: `
+<template></template>
+<page-query>
+  query Blog {
+    allWordPressPost(limit: 5) {
+      edges {
+        node {
+          id
+
+          
+          title
+        }
+      }
+    }
+  }
+</page-query>
+    `,
+      output: `
+<template></template>
+<page-query>
+  query Blog {
+    allWordPressPost(limit: 5) {
+      edges {
+        node {
+          id
+
           title
         }
       }


### PR DESCRIPTION
<!-- Fill all list -->

# Check

- [x] Pass the rule's test. : `npm run test`
- [ ] Fill the rule's docs.
- [ ] Create files by Hygen. : `npm run gen:rule`

<!-- Explanation of this PRs -->

# What

Support break line.

## Sample

This is origin code.

```vue
<page-query>
  fragment RankingParts on TourRanking {
    id
    rankings: data {
      rank
      nickname
      score
      badge: pin_badge_image_url
      ranking_started_at
      ranking_finished_at
    }
  }

  query($id: ID, $prevId: ID, $nextId: ID) {
    ranking: tourRanking(id: $id) {
      ...RankingParts
    }
    next: tourRanking(id: $prevId) {
      ...RankingParts
    }
    prev: tourRanking(id: $nextId) {
      ...RankingParts
    }
  }
</page-query>
```

If we use `fix` option...

### Before

```vue
<page-query>
  fragment RankingParts on TourRanking {
    id
    rankings: data {
      rank
      nickname
      score
      badge: pin_badge_image_url
      ranking_started_at
      ranking_finished_at
    }
  }
  query($id: ID, $prevId: ID, $nextId: ID) {
    ranking: tourRanking(id: $id) {
      ...RankingParts
    }
    next: tourRanking(id: $prevId) {
      ...RankingParts
    }
    prev: tourRanking(id: $nextId) {
      ...RankingParts
    }
  }
</page-query>
```

OMG. Break line is gone...

### After

```vue
<page-query>
  fragment RankingParts on TourRanking {
    id
    rankings: data {
      rank
      nickname
      score
      badge: pin_badge_image_url
      ranking_started_at
      ranking_finished_at
    }
  }

  query($id: ID, $prevId: ID, $nextId: ID) {
    ranking: tourRanking(id: $id) {
      ...RankingParts
    }
    next: tourRanking(id: $prevId) {
      ...RankingParts
    }
    prev: tourRanking(id: $nextId) {
      ...RankingParts
    }
  }
</page-query>
```

Looks good!

# Related issue
close #43 