### PR TITLE
fix(use-env-prefix): consider that env file does not exist

### DIFF
--- a/lib/rules/use-env-prefix.ts
+++ b/lib/rules/use-env-prefix.ts
@@ -51,15 +51,20 @@ export = createRule<[Options], MessageIds>({
   create(context) {
     const path = getPathFromProjectRoot(context.getFilename(), process.cwd());
 
-    const pathsForBrowserfileOption = context.options[0]
-      ?.pathsForBrowserfile || ["src/**/*"];
-    const envPathOption = context.options[0]?.envPath || ".env";
+    const options = {
+      pathsForBrowserfile: context.options[0]?.pathsForBrowserfile || [
+        "src/**/*",
+      ],
+      envPath: context.options[0]?.envPath || ".env",
+    };
 
-    const isClientfile = pathsForBrowserfileOption.some((clientPath) =>
+    const isClientfile = options.pathsForBrowserfile.some((clientPath) =>
       minimatch(path, clientPath)
     );
 
-    const envSource = Fs.readFileSync(envPathOption, { encoding: "utf8" });
+    if (!Fs.existsSync(options.envPath)) return {};
+    const envSource = Fs.readFileSync(options.envPath, { encoding: "utf8" });
+
     const parsedEnvSource = new Env(envSource).parse();
 
     return {

--- a/tests/lib/rules/fixtures/use-env-prefix/valid/03/client.js
+++ b/tests/lib/rules/fixtures/use-env-prefix/valid/03/client.js
@@ -1,0 +1,11 @@
+module.exports = {
+  plugins: [
+    {
+      use: "@gridsome/source-plugin",
+      options: {
+        username: "user",
+        password: "password",
+      },
+    },
+  ],
+};

--- a/tests/lib/rules/use-env-prefix.spec.ts
+++ b/tests/lib/rules/use-env-prefix.spec.ts
@@ -44,6 +44,21 @@ tester.run("use-env-prefix", rule, {
         },
       ],
     },
+    {
+      filename: path.join(process.cwd(), "src/client.js"),
+      ...loadFixture({
+        fixtureDirectory: "valid/03",
+        filenames: {
+          code: "client.js",
+        },
+      }),
+      options: [
+        {
+          pathsForBrowserfile: ["src/**/*"],
+          envPath: "tests/lib/rules/fixtures/use-env-prefix/valid/03/.env",
+        },
+      ],
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
<!-- Fill all list -->

# Check

- [ ] Pass the rule's test. : `npm run test`
- [ ] Fill the rule's docs.
- [ ] Create files by Hygen. : `npm run gen:rule`

<!-- Explanation of this PRs -->

# What
Previously, use-env-prefix does not consider case that env file does not exist on the project.
Now, the problem is solved.

# Related issue
